### PR TITLE
fix mismatches between some label name

### DIFF
--- a/sjtuthesis.cfg
+++ b/sjtuthesis.cfg
@@ -28,17 +28,17 @@
 %%
 %% labels and values used in title page for english version
 %%
-\def\sjtu@label@studentname{学生姓名：}
+\def\sjtu@label@author{学生姓名：}
 \def\sjtu@label@studentnumber{学生学号：}
 \def\sjtu@label@major{专~~~~~~~~业：}
 \def\sjtu@label@advisor{指导教师：}
-\def\sjtu@label@institution{学院(系)：}
+\def\sjtu@label@institute{学院(系)：}
 
-\def\sjtu@value@studentname{某某}
+\def\sjtu@value@author{某某}
 \def\sjtu@value@studentnumber{512XXXXXXXX}
 \def\sjtu@value@major{Your major}
 \def\sjtu@value@advisor{Your advisor}
-\def\sjtu@value@institution{Your affiliation}
+\def\sjtu@value@institute{Your affiliation}
 
 
 

--- a/sjtuthesis.cls
+++ b/sjtuthesis.cls
@@ -446,8 +446,8 @@
     \def\tabcolsep{1pt}
     \def\arraystretch{1}
     \begin{tabular}{lc}
-      \kaishu{\sjtu@label@studentname} &\kaishu
-      \sjtuunderline[250pt]{\sjtu@value@studentname}
+      \kaishu{\sjtu@label@author} &\kaishu
+      \sjtuunderline[250pt]{\sjtu@value@author}
     \\
       \kaishu{\sjtu@label@studentnumber} &\kaishu
       \sjtuunderline[250pt]{\sjtu@value@studentnumber}
@@ -458,8 +458,8 @@
       \kaishu{\sjtu@label@advisor} &\kaishu
       \sjtuunderline[250pt]{\sjtu@value@advisor}
     \\  
-      \kaishu{\sjtu@label@institution} &\kaishu
-      \sjtuunderline[250pt]{\sjtu@value@institution}
+      \kaishu{\sjtu@label@institute} &\kaishu
+      \sjtuunderline[250pt]{\sjtu@value@institute}
     \end{tabular}
   \end{center}
   \vskip \stretch{0.5}


### PR DESCRIPTION
The are some mismatches between "studentname", "advisor", "institution", "institute", causing the modification of \author{} and \institute{} in id.tex file useless. I changed sjtuthesis.cfg and cls files to fix this bug.